### PR TITLE
Version1

### DIFF
--- a/include/utmatrix.h
+++ b/include/utmatrix.h
@@ -163,18 +163,20 @@ TVector<ValType> TVector<ValType>::operator*(const ValType &val)
 template <class ValType> // сложение
 TVector<ValType> TVector<ValType>::operator+(const TVector<ValType> &v)
 {
-	TVector <ValType> result(Size);
+	TVector <ValType> result(Size,StartIndex);
 	if (Size != v.Size)
 		throw (5);
 	for (int i = 0; i < Size; i++)
+	{
 		result.pVector[i] = pVector[i] + v.pVector[i];
+	}
 	return result;
 }
 
 template <class ValType> // вычитание
 TVector<ValType> TVector<ValType>::operator-(const TVector<ValType> &v)
 {
-	TVector <ValType> result(Size);
+	TVector <ValType> result(Size,StartIndex);
 	if (Size != v.Size)
 		throw (5);
 	for (int i = 0; i < Size; i++)

--- a/include/utmatrix.h
+++ b/include/utmatrix.h
@@ -167,9 +167,7 @@ TVector<ValType> TVector<ValType>::operator+(const TVector<ValType> &v)
 	if (Size != v.Size)
 		throw (5);
 	for (int i = 0; i < Size; i++)
-	{
 		result.pVector[i] = pVector[i] + v.pVector[i];
-	}
 	return result;
 }
 

--- a/test/test_tmatrix.cpp
+++ b/test/test_tmatrix.cpp
@@ -32,7 +32,15 @@ TEST(TMatrix, copied_matrix_is_equal_to_source_one)
 
 TEST(TMatrix, copied_matrix_has_its_own_memory)
 {
-  ADD_FAILURE();
+	TMatrix<int> b;
+	TMatrix<int> *m = new TMatrix<int>;
+	(*m)[0][0] = 1;
+	(*m)[0][1] = 2;
+	(*m)[1][1] = 1;
+	b = *m;
+	delete m;
+	EXPECT_EQ(1, b[0][0]);
+	EXPECT_EQ(2, b[0][1]);
 }
 
 TEST(TMatrix, can_get_size)
@@ -46,8 +54,6 @@ TEST(TMatrix, can_set_and_get_element)
 	TMatrix <int> m(3);
 	m[0][2] = 2;
 	 EXPECT_EQ(2, m[0][2]);
-	//ADD_FAILURE();
-	
 }
 
 TEST(TMatrix, throws_when_set_element_with_negative_index)
@@ -136,14 +142,12 @@ TEST(TMatrix, matrices_with_different_size_are_not_equal)
 	EXPECT_EQ(true, m1 != m2);
 }
 
-///////////////
-///not working/
-///////////////
+
 TEST(TMatrix, can_add_matrices_with_equal_size) ///Не прошел
 {
 	TMatrix <int> m1(3), m2(3),m3(3);
-	for (int i = 0; i<3; i++)
-		for (int j = i; j < 3; j++)
+	for (int i = 0; i<2; i++)
+		for (int j = i; j < 2; j++)
 		{
 			m1[i][j] = 1;
 			m2[i][j] = 3;
@@ -158,9 +162,7 @@ TEST(TMatrix, cant_add_matrices_with_not_equal_size)
 	EXPECT_ANY_THROW( m1 + m2);
 }
 
-///////////////
-///not working/
-///////////////
+
 TEST(TMatrix, can_subtract_matrices_with_equal_size)
 {
 	TMatrix <int> m1(3), m2(3), m3(3);
@@ -171,6 +173,7 @@ TEST(TMatrix, can_subtract_matrices_with_equal_size)
 			m2[i][j] = 3;
 			m3[i][j] = 4;
 		}
+
 	EXPECT_EQ(m1, m3 - m2);
 }
 

--- a/test/test_tmatrix.cpp
+++ b/test/test_tmatrix.cpp
@@ -146,8 +146,8 @@ TEST(TMatrix, matrices_with_different_size_are_not_equal)
 TEST(TMatrix, can_add_matrices_with_equal_size) ///Не прошел
 {
 	TMatrix <int> m1(3), m2(3),m3(3);
-	for (int i = 0; i<2; i++)
-		for (int j = i; j < 2; j++)
+	for (int i = 0; i<3; i++)
+		for (int j = i; j < 3; j++)
 		{
 			m1[i][j] = 1;
 			m2[i][j] = 3;

--- a/test/test_tvector.cpp
+++ b/test/test_tvector.cpp
@@ -39,10 +39,16 @@ TEST(TVector, copied_vector_is_equal_to_source_one) //Скопированный вектор равен
 
 TEST(TVector, copied_vector_has_its_own_memory) //Скопированный вектор имеет собственную память
 {
-	/*TVector <int> Vector1(5);
-	TVector <int> Vector2(Vector1);
-	EXPECT_EQ(5, Vector2.GetSize());*/
-	ADD_FAILURE();
+	TVector<int> b;
+	TVector<int> *a = new TVector<int>;
+
+	(*a)[0] = 1;
+	(*a)[1] = 2;
+	(*a)[2] = 3;
+	b = (*a);
+	delete a;
+	EXPECT_EQ(1, b[0]);
+	EXPECT_EQ(3, b[2]);
 
 }
 


### PR DESCRIPTION
Ошибки были в функциях сложения и вычитания векторов.
Сложение векторов происходит через третью переменную `result`
```
TVector<ValType> TVector<ValType>::operator+(const TVector<ValType> &v)
{
	TVector <ValType> result(Size);
	...............
	return result;
}
```
В конструктор инициализации вектора поступает лишь один аргумент - размер вектора, а стартовый индекс по умолчанию нулю. Проработав, функция  сложения векторов возвращает объект со стартовым индексом 0. В матрицах  у каждого вектора есть свой стартовый индекс. при сравнении векторов сравниваются и их стартовые индексы
bool TVector<ValType>::operator==(const TVector &v) const
```
{
	if ((Size != v.Size) || ( StartIndex !=v.StartIndex))
		return false;
.....
}
```
 В тестах написав
`EXPECT_EQ(m3, m1 + m2);`
все вектора из m3 имеют разные стартовые индексы, а в m1+m2 все стартовые индексы равны нулю, поэтому и не происходило сравнение, поэтому и не работал тест.
